### PR TITLE
[AST-46] Language server command to request available pin mappings

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -30,7 +30,7 @@ import { URI } from "vscode-uri";
 import * as jsonc from "jsonc-parser";
 import * as fs from "fs";
 import * as path from "path";
-import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
 
 const HW_DEFINITION_SCHEMA_URL = "https://raw.githubusercontent.com/Azure-Sphere-Tools/hardware-definition-schema/master/hardware-definition-schema.json";
 
@@ -106,7 +106,7 @@ connection.onInitialized(() => {
           const hwDefinition = await checkCurrentHwDefinition(event.arguments[0]);
 
           if (hwDefinition) {
-            console.log(returnAvailablePinMappings(hwDefinition));
+            connection.console.log(returnAvailablePinMappings(hwDefinition).toString());
           }
         }
         break;
@@ -173,9 +173,9 @@ const checkCurrentHwDefinition = async (uri: string): Promise<HardwareDefinition
     displayErrorNotification("The current file is not a valid Hardware Definition (Must be a JSON file).");
     return;
   }
-  // const text = documents.get(URI.parse(uri).fsPath)?.getText();
   const currentFilePath = URI.parse(uri).fsPath;
-  const text = readFileSync(currentFilePath, "utf8");
+  const text = await readFile(currentFilePath, "utf8");
+
   if (!text) {
     displayErrorNotification("Error reading current file");
     return;

--- a/server/src/suggestions.ts
+++ b/server/src/suggestions.ts
@@ -4,7 +4,7 @@ import { Position } from "vscode-languageserver-textdocument";
 import { HardwareDefinition, isInsideRange, PinMapping } from "./hardwareDefinition";
 import { validateNamesAndMappings } from "./validator";
 
-export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinType = "Gpio"): string[] {
+export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinType?: string): string[] {
   let allPinMappings: PinMapping[] = [];
   const validPinMappings: string[] = [];
   for (const imported of hwDefinition.imports) {
@@ -14,11 +14,15 @@ export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinTy
   const invalidPinMappings: Set<PinMapping> = new Set(validateNamesAndMappings(hwDefinition, true).map((diagnostic) => <PinMapping>diagnostic.data));
 
   for (const pinMapping of allPinMappings) {
-    if (!invalidPinMappings.has(pinMapping) && pinMapping.type == pinType && !usedPinNames.has(pinMapping.name)) {
+    const validPins = !invalidPinMappings.has(pinMapping) && !usedPinNames.has(pinMapping.name);
+    if (pinType && pinMapping.type == pinType && validPins) {
+      validPinMappings.push(pinMapping.name);
+    }
+
+    if (!pinType && validPins) {
       validPinMappings.push(pinMapping.name);
     }
   }
-
   return validPinMappings;
 }
 

--- a/server/src/suggestions.ts
+++ b/server/src/suggestions.ts
@@ -4,10 +4,9 @@ import { Position } from "vscode-languageserver-textdocument";
 import { HardwareDefinition, isInsideRange, PinMapping } from "./hardwareDefinition";
 import { validateNamesAndMappings } from "./validator";
 
-export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinType = "gpio"): string[] {
+export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinType = "Gpio"): string[] {
   let allPinMappings: PinMapping[] = [];
   const validPinMappings: string[] = [];
-
   for (const imported of hwDefinition.imports) {
     allPinMappings = allPinMappings.concat(imported.pinMappings);
   }
@@ -15,7 +14,7 @@ export function getPinMappingSuggestions(hwDefinition: HardwareDefinition, pinTy
   const invalidPinMappings: Set<PinMapping> = new Set(validateNamesAndMappings(hwDefinition, true).map((diagnostic) => <PinMapping>diagnostic.data));
 
   for (const pinMapping of allPinMappings) {
-    if ((!invalidPinMappings.has(pinMapping) || pinMapping.type == pinType) && !usedPinNames.has(pinMapping.name)) {
+    if (!invalidPinMappings.has(pinMapping) && pinMapping.type == pinType && !usedPinNames.has(pinMapping.name)) {
       validPinMappings.push(pinMapping.name);
     }
   }

--- a/server/src/test/suggestions.test.ts
+++ b/server/src/test/suggestions.test.ts
@@ -23,14 +23,13 @@ suite("getPinMappingSuggestions", () => {
   });
 
   test("Only suggests Pin Mappings that are directly imported", () => {
-    
     const basePin1 = new PinMapping("BASE_GPIO0", "Gpio", undefined, 0, anyRange());
     const basePin2 = new PinMapping("BASE_GPIO1", "Gpio", undefined, 1, anyRange());
     const baseHwDef = new HardwareDefinition(asURI("baseHwDef.json"), undefined, [basePin1, basePin2]);
 
     const directlyImportedPin = new PinMapping("ODM_GPIO0", "Gpio", basePin1.name, undefined, anyRange());
     const importedhwDefinition = new HardwareDefinition(asURI("importedHardwareDef.json"), undefined, [directlyImportedPin], [baseHwDef]);
-    
+
     const hwDefinitionFile = new HardwareDefinition(asURI("hardwareDef.json"), undefined, [], [importedhwDefinition]);
 
     const suggestedPinMappings = getPinMappingSuggestions(hwDefinitionFile, "Gpio");
@@ -40,17 +39,30 @@ suite("getPinMappingSuggestions", () => {
     assert.strictEqual(suggestedPinMappings.includes(basePin1.name), false);
     assert.strictEqual(suggestedPinMappings.includes(basePin2.name), false);
   });
-});
 
+  test("Gets Pin Mapping Suggestions of different types if pinType is undefined", () => {
+    const gpioPin1 = new PinMapping("GPIO0", "Gpio", undefined, 0, range(0, 0, 0, 5));
+    const gpioPin2 = new PinMapping("GPIO1", "Gpio", undefined, 1, range(1, 0, 1, 5));
+    const pinWithDifferentType = new PinMapping("PWM0", "Pwm", undefined, 28, range(2, 0, 2, 5));
+    const importedhwDefFilePath = "my_app/importedHardwareDef.json";
+    const importedhwDefinitionFile = new HardwareDefinition(asURI(importedhwDefFilePath), undefined, [gpioPin1, gpioPin2, pinWithDifferentType]);
+
+    const hwDefFilePath = "my_app/hardwareDef.json";
+    const validPin = new PinMapping("LED", "Gpio", "GPIO1", undefined, range(0, 0, 0, 5));
+    const hwDefinitionFile = new HardwareDefinition(asURI(hwDefFilePath), undefined, [validPin], [importedhwDefinitionFile]);
+
+    const validPinMappings = getPinMappingSuggestions(hwDefinitionFile);
+
+    assert.strictEqual(validPinMappings.length, 2);
+  });
+});
 
 suite("pinMappingCompletionItemsAtPosition", () => {
   test("Returns Completion Items if caret inside 'Mapping' property", () => {
-    
-
     const gpioPin = new PinMapping("GPIO0", "Gpio", undefined, 0, anyRange());
     const importedhwDefinition = new HardwareDefinition(asURI("importedHardwareDef.json"), undefined, [gpioPin]);
-    
-    const caretPosition: Position = {line: 0, character: 6}; 
+
+    const caretPosition: Position = { line: 0, character: 6 };
     const pinWithEmptyMapping = new PinMapping("LED", "Gpio", "", undefined, anyRange());
     pinWithEmptyMapping.mappingPropertyRange = range(0, 5, 0, 7);
     const hwDefinitionFile = new HardwareDefinition(asURI("hardwareDef.json"), undefined, [pinWithEmptyMapping], [importedhwDefinition]);
@@ -58,7 +70,7 @@ suite("pinMappingCompletionItemsAtPosition", () => {
     const actualSuggestions = pinMappingCompletionItemsAtPosition(hwDefinitionFile, caretPosition);
 
     assert.strictEqual(actualSuggestions.length, 1);
-    const actualSuggestion = <TextEdit>actualSuggestions[0].textEdit; 
+    const actualSuggestion = <TextEdit>actualSuggestions[0].textEdit;
     assert.strictEqual(actualSuggestion.newText, `"${gpioPin.name}"`);
     assert.strictEqual(actualSuggestion.range, pinWithEmptyMapping.mappingPropertyRange);
   });

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,63 +1,70 @@
 {
-	"name": "azsphere-hardware-definition-tools",
-	"displayName": "Azure Sphere Hardware Definition Tools",
-	"description": "VSCode extension for Azure Sphere Hardware Definition support",
-	"author": "UCL IXN",
-	"contributors": [
-		"Jiachen Weng",
-		"Tsung-Hai Tsai",
-		"Denoy Hossain",
-		"Dorin Botan",
-		"Omar Beyhum"
-	],
-	"publisher": "ucl-ixn",
-	"license": "MIT",
-	"version": "1.0.0",
-	"categories": [],
-	"keywords": [],
-	"engines": {
-		"vscode": "^1.52.0"
-	},
-	"activationEvents": [
-		"onLanguage:json",
-		"onLanguage:plaintext",
-		"onLanguage:cmake"
-	],
-	"main": "./dist/extension",
-	"contributes": {
-		"configuration": {
-			"type": "object",
-			"title": "Azure Sphere Tools",
-			"properties": {
-				"AzureSphere.SdkPath": {
-					"scope": "window",
-					"type": "string",
-					"description": "Path to the Azure Sphere SDK directory."
-				},
-				"azureSphereToolsLanguageServer.trace.server": {
-					"scope": "window",
-					"type": "string",
-					"enum": [
-						"off",
-						"messages",
-						"verbose"
-					],
-					"default": "off",
-					"description": "Traces the communication between VS Code and the language server."
-				}
-			}
-		}
-	},
-	"scripts": {
-		"build": "tsc -b",
-		"vscode:prepublish": "sh ./prepublish.sh"
-	},
-	"dependencies": {
-		"vscode-languageclient": "^7.0.0"
-	},
-	"devDependencies": {
-		"@types/vscode": "^1.52.0",
-		"vscode-test": "^1.3.0",
-		"typescript": "^4.3.2"
-	}
+  "name": "azsphere-hardware-definition-tools",
+  "displayName": "Azure Sphere Hardware Definition Tools",
+  "description": "VSCode extension for Azure Sphere Hardware Definition support",
+  "author": "UCL IXN",
+  "contributors": [
+    "Jiachen Weng",
+    "Tsung-Hai Tsai",
+    "Denoy Hossain",
+    "Dorin Botan",
+    "Omar Beyhum"
+  ],
+  "publisher": "ucl-ixn",
+  "license": "MIT",
+  "version": "1.0.0",
+  "categories": [],
+  "keywords": [],
+  "engines": {
+    "vscode": "^1.52.0"
+  },
+  "activationEvents": [
+    "onLanguage:json",
+    "onLanguage:plaintext",
+    "onLanguage:cmake"
+  ],
+  "main": "./dist/extension",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Azure Sphere Tools",
+      "properties": {
+        "AzureSphere.SdkPath": {
+          "scope": "window",
+          "type": "string",
+          "description": "Path to the Azure Sphere SDK directory."
+        },
+        "azureSphereToolsLanguageServer.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the language server."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "azsphere-hardware-definition-tools.availablePins",
+        "category": "Azure Sphere Tools",
+        "title": "Get available pin mappings given a Hardware Definition"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "vscode:prepublish": "sh ./prepublish.sh"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.52.0",
+    "vscode-test": "^1.3.0",
+    "typescript": "^4.3.2"
+  }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,35 +1,17 @@
+import { homedir } from "os";
 import * as path from "path";
-import { workspace, ExtensionContext, ExtensionMode } from "vscode";
-
-import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind,
-} from "vscode-languageclient/node";
+import { workspace, ExtensionContext, ExtensionMode, commands, window, InputBoxOptions, QuickPickItem } from "vscode";
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from "vscode-languageclient/node";
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
   let serverModule;
-  if (
-    context.extensionMode == ExtensionMode.Development ||
-    context.extensionMode == ExtensionMode.Test
-  ) {
+  if (context.extensionMode == ExtensionMode.Development || context.extensionMode == ExtensionMode.Test) {
     // if in development/test mode, run language server directly from language server project to enable breakpoints on source code
-    serverModule = context.asAbsolutePath(
-      path.join("..", "server", "dist", "server.js")
-    );
+    serverModule = context.asAbsolutePath(path.join("..", "server", "dist", "server.js"));
   } else {
-    serverModule = context.asAbsolutePath(
-      path.join(
-        "embedded-language-server",
-        "node_modules",
-        "azsphere-hardware-definition-language-server",
-        "dist",
-        "server.js"
-      )
-    );
+    serverModule = context.asAbsolutePath(path.join("embedded-language-server", "node_modules", "azsphere-hardware-definition-language-server", "dist", "server.js"));
   }
 
   console.log(
@@ -57,7 +39,7 @@ export function activate(context: ExtensionContext) {
     documentSelector: [
       { scheme: "file", language: "json" },
       { scheme: "file", language: "plaintext" },
-      { scheme: "file", language: "cmake" }
+      { scheme: "file", language: "cmake" },
     ],
     synchronize: {
       // Notify the server about file changes to '.clientrc files contained in the workspace
@@ -66,16 +48,21 @@ export function activate(context: ExtensionContext) {
   };
 
   // Create the language client and start the client.
-  client = new LanguageClient(
-    "azureSphereToolsLanguageServer",
-    "AZ Sphere Hardware Language Server",
-    serverOptions,
-    clientOptions
-  );
+  client = new LanguageClient("azureSphereToolsLanguageServer", "AZ Sphere Hardware Language Server", serverOptions, clientOptions);
 
   // Start the client. This will also launch the server
-  client.start();
+  const disposable = client.start();
+
+  context.subscriptions.push(
+    disposable,
+    commands.registerCommand("azsphere-hardware-definition-tools.availablePins", () => displayHwDefinitionList())
+  );
 }
+
+const displayHwDefinitionList = async () => {
+  const currentlyOpenTabfilePath: string = window.activeTextEditor?.document.uri.fsPath;
+  commands.executeCommand("availablePins", currentlyOpenTabfilePath);
+};
 
 export function deactivate(): Thenable<void> | undefined {
   if (!client) {


### PR DESCRIPTION
Added a command to the language server which takes a hardware definition file as input. When the command is sent from the client to the server, the server responds with the list of available pin mappings along with their type.

For integration purposes: On VS Code extension client-side, add functionality to call the new command and print the pin mappings console.log