### PR TITLE
[AST-64] Publish VSCode extension to Marketplace on merge new version into master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
 name: Publish
 
 on:
+  workflow_run:
+    workflows: [ "Build and Test" ]
+    branches: [ master ]
+    types: [ completed ]
   workflow_dispatch:
 
 env:
@@ -10,25 +14,26 @@ env:
 jobs:
   publish-vscode:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install dependencies
+      - name: Install dependencies (step 1/3)
         run: npm ci
-      - name: Start xvfb
-        run: |
-          /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          echo ">>> Started xvfb"
-        shell: bash
-      - run: npm run build --if-present
-      - run: npm test
+      - name: Install dependencies (step 2/3)
+        run: npm install -g vsce
+      - name: Install dependencies (step 3/3)
+        run: sudo apt -y install jq
+      - name: Pack extension
+        run: (cd vscode-extension; vsce package)
+      - name: Publish to Visual Studio Marketplace
+        run: npm run publish
         env:
-          DISPLAY: ":99.0" # Only necessary for linux tests
-      - run: npm install -g vsce
-      - run: (cd vscode-extension && yes | vsce package)
+          EXTENSION_PATH: "./vscode-extension"
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -39,6 +44,7 @@ jobs:
 
   publish-visualstudio:
     runs-on: windows-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"watch": "tsc -b -w",
 		"postinstall": "cd vscode-extension && npm install && cd ../server && npm install && cd ..",
 		"test": "sh ./scripts/e2e.sh",
-		"coverage": "nyc ./scripts/e2e.sh ONLY_UNIT_TESTS && nyc report --reporter=html --reporter=json-summary && nyc check-coverage --statements 90"
+		"coverage": "nyc ./scripts/e2e.sh ONLY_UNIT_TESTS && nyc report --reporter=html --reporter=json-summary && nyc check-coverage --statements 90",
+		"publish": "bash ./scripts/publish.sh $EXTENSION_PATH $VSCE_PAT"
 	},
 	"devDependencies": {
 		"@types/mocha": "^8.2.2",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+publish() {
+  PROJECT=$(cat $1/package.json 2>/dev/null | jq -r '.name')
+  PUBLISHER=$(cat $1/package.json 2>/dev/null | jq -r '.publisher')
+
+  if [ -z "${PROJECT}" ] \
+  || [ "${PROJECT}" == "null" ] \
+  || [ -z "${PUBLISHER}" ] \
+  || [ "${PUBLISHER}" == "null" ]
+  then
+    echo "Project name and/or publisher is missing in $1/package.json"
+    return 1
+  fi
+
+  VERSION=$(cat $1/package.json 2>/dev/null | jq -r '.version')
+  PUBLIC_VERSION=$(npx vsce show ${PUBLISHER}.${PROJECT} --json | jq -r '.versions[0].version' 2>/dev/null)
+
+  printf '%s\n%s\n' ${VERSION} ${PUBLIC_VERSION} | sort --check=quiet --version-sort
+  OUTDATED=$?
+
+  # printf '%s - %s : %s\n' ${VERSION} ${PUBLIC_VERSION} ${OUTDATED}
+
+  if [ ${OUTDATED} -ne 0 ]
+  then
+    echo 'Publishing VSCode extension to Marketplace'
+
+    # Publish existing package if it exists
+    if [ -f $1/${PROJECT}-${VERSION}.vsix ]
+    then
+      cd $1; npx vsce publish --packagePath ${PROJECT}-${VERSION}.vsix -p $2 2>/dev/null 2>/dev/null
+    else
+      cd $1; npx vsce publish -p $2 2>/dev/null
+    fi
+
+    return 0
+  fi
+
+  echo "Skipped"
+  echo "Update version in $1/package.json to publish"
+}
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: publish.sh PATH TOKEN"
+  echo "Build and publish extension under PATH to Visual Studio Marketplace."
+  exit
+fi
+
+publish $1 $2


### PR DESCRIPTION
On successful merge into master, the VSCode extension is published to Visual Studio Marketplace if its version (in package.json) is higher than the published one.